### PR TITLE
Port imath test suite

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -17,7 +17,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.43.0
+          - 1.51.0
         os:
           - ubuntu-latest
           - windows-latest
@@ -31,7 +31,7 @@ jobs:
         with:
           submodules: recursive
       # LLVM and Clang installation
-      # https://github.com/KyleMayes/clang-sys/blob/a0bcae1a9d7ab6ed8de010b0f5e2b2020c20d204/.github/workflows/ci.yml#L23-L35 
+      # https://github.com/KyleMayes/clang-sys/blob/a0bcae1a9d7ab6ed8de010b0f5e2b2020c20d204/.github/workflows/ci.yml#L23-L35
       # The clang and clang-sys crates' CI has example of installing LLVM and Clang
       # along with how to update the environment variables (see Build & Test) so
       # that bindgen can find libclang and depedencies

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -5,6 +5,6 @@ condense_wildcard_suffixes = true
 format_strings = true
 reorder_impl_items = true
 reorder_modules = true
-merge_imports = true
+imports_granularity="Crate"
 use_field_init_shorthand = true
 report_fixme = "Unnumbered"

--- a/src/integer/comparison.rs
+++ b/src/integer/comparison.rs
@@ -159,7 +159,7 @@ mod test {
 
     #[test]
     fn compare_big_integers_with_small() {
-        let a = Integer::from_string_repr("1234567890").unwrap();
+        let a = Integer::from_string_repr("1234567890", 10).unwrap();
 
         assert!(a > 0);
         assert!(a != 987_654_321);

--- a/src/integer/conversions.rs
+++ b/src/integer/conversions.rs
@@ -211,13 +211,13 @@ cfg_if::cfg_if! {
     } else {
         impl From<u32> for Integer {
             fn from(src: u32) -> Self {
-                Self::from_string_repr(src).expect("Conversion from string failed")
+                Self::from_string_repr(src, 10).expect("Conversion from string failed")
             }
         }
 
         impl From<&u32> for Integer {
             fn from(src: &u32) -> Self {
-                Self::from_string_repr(src).expect("Conversion from string failed")
+                Self::from_string_repr(src, 10).expect("Conversion from string failed")
             }
         }
 
@@ -238,13 +238,13 @@ cfg_if::cfg_if! {
 
         impl From<i64> for Integer {
             fn from(src: i64) -> Self {
-                Self::from_string_repr(src).expect("Conversion from string failed")
+                Self::from_string_repr(src, 10).expect("Conversion from string failed")
             }
         }
 
         impl From<&i64> for Integer {
             fn from(src: &i64) -> Self {
-                Self::from_string_repr(*src).expect("Conversion from string failed")
+                Self::from_string_repr(*src, 10).expect("Conversion from string failed")
             }
         }
 
@@ -266,13 +266,13 @@ cfg_if::cfg_if! {
 
 impl From<u64> for Integer {
     fn from(src: u64) -> Self {
-        Self::from_string_repr(src).expect("Conversion from string failed")
+        Self::from_string_repr(src, 10).expect("Conversion from string failed")
     }
 }
 
 impl From<&u64> for Integer {
     fn from(src: &u64) -> Self {
-        Self::from_string_repr(*src).expect("Conversion from string failed")
+        Self::from_string_repr(*src, 10).expect("Conversion from string failed")
     }
 }
 
@@ -298,13 +298,13 @@ impl TryFrom<&Integer> for u64 {
 
 impl From<i128> for Integer {
     fn from(src: i128) -> Self {
-        Self::from_string_repr(src).expect("Conversion from string failed")
+        Self::from_string_repr(src, 10).expect("Conversion from string failed")
     }
 }
 
 impl From<&i128> for Integer {
     fn from(src: &i128) -> Self {
-        Self::from_string_repr(*src).expect("Conversion from string failed")
+        Self::from_string_repr(*src, 10).expect("Conversion from string failed")
     }
 }
 
@@ -330,13 +330,13 @@ impl TryFrom<&Integer> for i128 {
 
 impl From<u128> for Integer {
     fn from(src: u128) -> Self {
-        Self::from_string_repr(src).expect("Conversion from string failed")
+        Self::from_string_repr(src, 10).expect("Conversion from string failed")
     }
 }
 
 impl From<&u128> for Integer {
     fn from(src: &u128) -> Self {
-        Self::from_string_repr(*src).expect("Conversion from string failed")
+        Self::from_string_repr(*src, 10).expect("Conversion from string failed")
     }
 }
 

--- a/tests/creachadair_imath.rs
+++ b/tests/creachadair_imath.rs
@@ -200,3 +200,26 @@ fn check_test_data_mul() {
         }
     }
 }
+
+#[test]
+fn check_test_data_neg() {
+    let file_contents = read_file(tc_path!("neg.tc"));
+    let test_cases = file_contents
+        .lines()
+        .filter(filter_comments_and_whitespace)
+        .map(TestCase::<2, 1>::parse);
+
+    for tc in test_cases {
+        match tc.operator {
+            "neg" => {
+                let input = parse_integer(tc.arguments[0]);
+                let output = -input;
+
+                let expected = parse_integer(tc.outputs[0]);
+
+                assert_eq!(output, expected);
+            }
+            x => panic!("unknown operator: {:?}", x),
+        }
+    }
+}

--- a/tests/creachadair_imath.rs
+++ b/tests/creachadair_imath.rs
@@ -1,0 +1,202 @@
+use reckoner::Integer;
+use std::{convert::TryFrom, fs::File, io::Read, mem::MaybeUninit, path::Path};
+
+#[derive(Debug)]
+struct TestCase<'i, const I: usize, const O: usize> {
+    operator: &'i str,
+    arguments: [&'i str; I],
+    outputs: [&'i str; O],
+}
+
+impl<'i, const I: usize, const O: usize> TestCase<'i, I, O> {
+    fn parse(input: &'i str) -> Self {
+        let mut segments = input.split(':');
+        let operator = segments.next().expect("unable to split operator");
+        let mut arguments = array_from_iter(
+            segments
+                .next()
+                .expect("unable to split arguments")
+                .split(","),
+        );
+        let outputs = array_from_iter(
+            segments
+                .next()
+                .expect("unable to split outputss")
+                .split(","),
+        );
+
+        // resolve back references of the form `=n` where `n` is the referenced index
+        for idx in 0..arguments.len() {
+            if arguments[idx].starts_with('=') {
+                let backref = arguments[idx]
+                    .trim_start_matches('=')
+                    .parse::<usize>()
+                    .expect("unable to parse backref index");
+
+                // the backref indices are 1-based, so need to adjust to array indexing.
+                arguments[idx] = arguments[backref - 1];
+            }
+        }
+
+        TestCase {
+            operator,
+            arguments,
+            outputs,
+        }
+    }
+}
+
+fn array_from_iter<T, const N: usize>(mut iter: impl Iterator<Item = T>) -> [T; N] {
+    // TODO: replace with `MaybeUninit::uninit_array` when stable
+    // SAFETY: An uninitialized `[MaybeUninit<_>; LEN]` is valid.
+    let mut arr = unsafe { MaybeUninit::<[MaybeUninit<T>; N]>::uninit().assume_init() };
+
+    for idx in 0..N {
+        let item = iter.next().expect("Unable to extract all N items");
+        unsafe { arr[idx].as_mut_ptr().write(item) }
+    }
+
+    // TODO: replace with `MaybeUninit::array_assume_init` when stable
+    // SAFETY:
+    // * Earlier blocks guarantee all N elements are initialized
+    // * `MaybeUninit<T>` and T are guaranteed to have the same layout
+    // * MaybeUnint does not drop, so there are no double-frees
+    // And thus the conversion is safe
+    unsafe { (&arr as *const _ as *const [T; N]).read() }
+}
+
+fn read_file(path: impl AsRef<Path>) -> String {
+    let mut file = File::open(path.as_ref()).expect("unable to open file for read");
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)
+        .expect("unable to read file to string");
+
+    contents
+}
+
+fn filter_comments_and_whitespace(input: &&str) -> bool {
+    let trimmed = input.trim_start();
+
+    return !(trimmed.starts_with('#') || trimmed.is_empty());
+}
+
+macro_rules! tc_path {
+    ($s:expr) => {
+        concat!("creachadair-imath-sys/vendor/imath/tests/", $s)
+    };
+}
+
+fn parse_integer(s: &str) -> Integer {
+    let (s, radix) = if let Some(s) = s.strip_prefix("#") {
+        let radix = match s.chars().next() {
+            Some('x') | Some('X') => 16,
+            Some('d') | Some('D') => 10,
+            Some('o') | Some('O') => 8,
+            Some('b') | Some('B') => 2,
+            x => panic!("unable to parse radix symbol: '{:?}'", x),
+        };
+
+        (s.get(1..).expect("unable to slice remainder"), radix)
+    } else {
+        (s, 10)
+    };
+
+    Integer::from_string(s, radix).unwrap_or_else(|err| panic!("unable to parse: {:?}. {}", s, err))
+}
+
+#[test]
+fn check_test_data_add() {
+    let file_contents = read_file(tc_path!("add.tc"));
+    let test_cases = file_contents
+        .lines()
+        .filter(filter_comments_and_whitespace)
+        .map(TestCase::<3, 1>::parse);
+
+    for tc in test_cases {
+        match tc.operator {
+            "add" => {
+                let lhs = parse_integer(tc.arguments[0]);
+                let rhs = parse_integer(tc.arguments[1]);
+                let result = lhs + rhs;
+                let expected = parse_integer(tc.outputs[0]);
+
+                assert_eq!(result, expected);
+            }
+            "addv" => {
+                let lhs = parse_integer(tc.arguments[0]);
+                let rhs_large = parse_integer(tc.arguments[1]);
+                let rhs = i32::try_from(rhs_large).expect("unable to parse as small int");
+                let result = lhs + rhs;
+                let expected = parse_integer(tc.outputs[0]);
+
+                assert_eq!(result, expected);
+            }
+            x => panic!("unknown operator: {:?}", x),
+        }
+    }
+}
+
+#[test]
+fn check_test_data_sub() {
+    let file_contents = read_file(tc_path!("sub.tc"));
+    let test_cases = file_contents
+        .lines()
+        .filter(filter_comments_and_whitespace)
+        .map(TestCase::<3, 1>::parse);
+
+    for tc in test_cases {
+        match tc.operator {
+            "sub" => {
+                let lhs = parse_integer(tc.arguments[0]);
+                let rhs = parse_integer(tc.arguments[1]);
+                let result = lhs - rhs;
+                let expected = parse_integer(tc.outputs[0]);
+
+                assert_eq!(result, expected);
+            }
+            "subv" => {
+                let lhs = parse_integer(tc.arguments[0]);
+                let rhs_large = parse_integer(tc.arguments[1]);
+                let rhs = i32::try_from(rhs_large).expect("unable to parse as small int");
+                let result = lhs - rhs;
+                let expected = parse_integer(tc.outputs[0]);
+
+                assert_eq!(result, expected);
+            }
+            x => panic!("unknown operator: {:?}", x),
+        }
+    }
+}
+
+#[test]
+fn check_test_data_mul() {
+    let file_contents = read_file(tc_path!("mul.tc"));
+    let test_cases = file_contents
+        .lines()
+        .filter(filter_comments_and_whitespace)
+        .map(TestCase::<3, 1>::parse);
+
+    for tc in test_cases {
+        match tc.operator {
+            "mul" => {
+                let lhs = parse_integer(tc.arguments[0]);
+                let rhs = parse_integer(tc.arguments[1]);
+                let result = lhs * rhs;
+                let expected = parse_integer(tc.outputs[0]);
+
+                assert_eq!(result, expected);
+            }
+            "mulv" => {
+                let lhs = parse_integer(tc.arguments[0]);
+                let rhs_large = parse_integer(tc.arguments[1]);
+                let rhs = i32::try_from(rhs_large).expect("unable to parse as small int");
+                let result = lhs * rhs;
+                let expected = parse_integer(tc.outputs[0]);
+
+                assert_eq!(result, expected);
+            }
+            "mulp2" => {} // ignore mulp2 tests as not currently exposed in `reckoner` API.
+            x => panic!("unknown operator: {:?}", x),
+        }
+    }
+}


### PR DESCRIPTION
Closes #7. Use the test data present in the `imath` repository to run a basic tests against the `reckoner` API.